### PR TITLE
Silence build warning running under yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:watch": "npx babel lib -w -d build",
     "lint": "eslint lib/**; exit 0",
     "lint:watch": "esw -w lib/**",
-    "prepare": "npm run build",
+    "prepare": "npm --scripts-prepend-node-path run build",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
Attempt to silence this warning on CI when this module is built via `yarn`:

```
npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1569341850170-0.8247446037378607/node but npm is using /usr/local/node-v10.15.3-linux-x64/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with. 
```